### PR TITLE
Depend on `its-it` only for gem development.

### DIFF
--- a/lib/modware/stack.rb
+++ b/lib/modware/stack.rb
@@ -1,4 +1,3 @@
-require 'its-it'
 require 'key_struct'
 
 module Modware
@@ -49,7 +48,7 @@ module Modware
       end
 
       def call_implementation(env, base_implementation)
-        if middleware = @middlewares.select(&it.respond_to?(:implement)).last
+        if middleware = @middlewares.select { |mw| mw.respond_to?(:implement) }.last
           middleware.implement(env)
         elsif base_implementation
           base_implementation.call env

--- a/modware.gemspec
+++ b/modware.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.1.0"
   spec.add_dependency "key_struct", "~> 0.4"
-  spec.add_dependency "its-it"
 
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency "bundler", "~> 1.7"
@@ -28,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-given"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "simplecov-gem-profile"
+  spec.add_development_dependency "its-it"
 end

--- a/spec/support/factory.rb
+++ b/spec/support/factory.rb
@@ -1,3 +1,5 @@
+require 'its-it'
+
 module Factory
   def self.middleware(n=nil, before: true, after: true, around: true, implement: true, other: nil)
 


### PR DESCRIPTION
This will help anyone who wants to use `modware`, but doesn't want the `its-it` Kernel methods.

The kernel methods are still available in the specs, which is convenient.
